### PR TITLE
Fix regression in AspNetCore module as discussed in this issue

### DIFF
--- a/src/Suave.IIS/Configuration.fs
+++ b/src/Suave.IIS/Configuration.fs
@@ -33,10 +33,10 @@ let parsePort port =
 
 /// Parse configuration setup from command line args
 let parseSetup (args:string []) =
-    match args |> Array.length with
-    | x when x = 2 -> { Port = parsePort args.[0]; Path = Some args.[1] } |> Some
-    | x when x = 1 -> { Port = parsePort args.[0]; Path = None } |> Some
-    | _  -> None
+    match args with
+    | [| port; path |] -> { Port = parsePort port; Path = Some path } |> Some
+    | [| port |] -> { Port = parsePort port; Path = None } |> Some
+    | _ -> None
 
 /// Set Suave port based on command line args setup
 let withPort (args:string []) config =

--- a/src/Suave.IIS/Configuration.fs
+++ b/src/Suave.IIS/Configuration.fs
@@ -1,6 +1,7 @@
 ﻿module Suave.IIS.Configuration
 
 open Suave
+open System
 open System.Net
 
 type Setup = {
@@ -8,11 +9,33 @@ type Setup = {
     Path: string option
 }
 
+let tryGetPortFromEnv () =
+    match Environment.GetEnvironmentVariable "ASPNETCORE_PORT" with
+    | null -> None
+    | port -> Some port
+
+let tryParsePort port =
+    match UInt16.TryParse port with
+    | true, port -> Some port
+    | false, _ -> None
+
+let tryReadPort port =
+    match tryParsePort port with
+    | Some port -> Some port
+    | None ->
+        tryGetPortFromEnv ()
+        |> Option.bind tryParsePort
+
+let parsePort port =
+    match tryReadPort port with
+    | Some port -> port
+    | None -> failwithf "Please provide a valid port as the first argument: %s" port
+
 /// Parse configuration setup from command line args
 let parseSetup (args:string []) =
     match args |> Array.length with
-    | x when x = 2 -> { Port = uint16 args.[0]; Path = Some args.[1] } |> Some
-    | x when x = 1 -> { Port = uint16 args.[0]; Path = None } |> Some
+    | x when x = 2 -> { Port = parsePort args.[0]; Path = Some args.[1] } |> Some
+    | x when x = 1 -> { Port = parsePort args.[0]; Path = None } |> Some
     | _  -> None
 
 /// Set Suave port based on command line args setup


### PR DESCRIPTION
AspNetCoreModule doesn't resolve environment arguments anymore: #6 
This fixes the issue discussed here: aspnet/AspNetCoreModule#117

As I side note I'm not a big fan of reading the port from the environment variable.